### PR TITLE
Remove the trailing ';' on odd and three css class selectors

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,11 +1,11 @@
 .odd {
     background-color: rgb(237, 143, 109);
     font-family: "Verdana", "DejaVu", "Sans", sans-serif ;
-};
+}
 
 .three {
     font-size: 24px;
-};
+}
 
 #two {
     color: #0000ff;


### PR DESCRIPTION
the ";" that were left at the end of the .odd and .three selectors were messing up the css file. The ";" is used to signify the end of a line in JavaScript but in CSS they shouldn't be there.